### PR TITLE
modify_test

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -1,88 +1,398 @@
 require:
+  - rubocop-minitest
+  - rubocop-packaging
   - rubocop-performance
   - rubocop-rails
+  - rubocop-md
 
 AllCops:
+  TargetRubyVersion: 3.2.4
+  # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
+  # to ignore them, so only the ones explicitly set in this file are enabled.
+  DisabledByDefault: true
+  # RuboCopの拡張機能の提案を有効にするかどうかを指定
   SuggestExtensions: false
-  # 最新のルールを適用する
-  NewCops: enable
-  # 何のルールに引っかかったか表示する
-  DisplayCopNames: true
-  # rubocop対象外(リポジトリ毎で調節)
+  # ルールの適用対象から除外するファイルやディレクトリを指定します
   Exclude:
-    - "bin/**/*"
-    - "db/**/*"
-    - "log/**/*"
-    - "tmp/**/*"
-    - "vendor/**/*"
-    - "lib/tasks/auto_annotate_models.rake"
-    - "config/environments/*"
-    - "config/puma.rb"
-    - "script/**/*"
+    - '**/tmp/**/*'
+    - '**/templates/**/*'
+    - '**/vendor/**/*'
+    - 'actionpack/lib/action_dispatch/journey/parser.rb'
+    - 'actionmailbox/test/dummy/**/*'
+    - 'activestorage/test/dummy/**/*'
+    - 'actiontext/test/dummy/**/*'
+    - 'tools/rail_inspector/test/fixtures/*'
+    - guides/source/debugging_rails_applications.md
+    - guides/source/active_support_instrumentation.md
+    - '**/node_modules/**/*'
+    - '**/CHANGELOG.md'
+    - '**/2_*_release_notes.md'
+    - '**/3_*_release_notes.md'
+    - '**/4_*_release_notes.md'
+    - '**/5_*_release_notes.md'
+    - '**/6_*_release_notes.md'
 
-### ルールのカスタマイズ
+# パフォーマンス関連のルールを除外するファイルやディレクトリを指定します
+Performance:
+  Exclude:
+    - '**/test/**/*'
 
-# 設定が厳しいので一旦全てfalseにする
-Metrics:
-  Enabled: false
+# assert_not を assert より優先
+Rails/AssertNot:
+  Include:
+    - '**/test/**/*'
 
-# 一行あたりの文字数
-Layout/LineLength:
-  Max: 120
+# Prefute_x を assert_not_x より優先
+Rails/RefuteMethods:
+  Include:
+    - '**/test/**/*'
 
-# メソッドの改行ルール
-Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented
+Rails/IndexBy:
+  Enabled: true
 
-# 日本語にコメントを許可
-Style/AsciiComments:
-  Enabled: false
+Rails/IndexWith:
+  Enabled: true
 
-# クラスにコメントを残さなくても良い
-Style/Documentation:
-  Enabled: false
+# and/or よりも &&/|| を優先
+Style/AndOr:
+  Enabled: true
 
-# コントローラ等のモジュールをネストしての宣言
-Style/ClassAndModuleChildren:
-  Enabled: false
+Layout/ClosingHeredocIndentation:
+  Enabled: true
 
-# 文字列のfreeze（Ruby3からは自動でfreezeされるので要らない）
+Layout/ClosingParenthesisIndentation:
+  Enabled: true
+
+# メソッド定義とコメントを整列
+Layout/CommentIndentation:
+  Enabled: true
+
+Layout/DefEndAlignment:
+  Enabled: true
+
+Layout/ElseAlignment:
+  Enabled: true
+
+# `end` を対応するキーワードや開始式に整列させますが、代入の場合はLHSに整列
+Layout/EndAlignment:
+  Enabled: true
+  EnforcedStyleAlignWith: variable
+  AutoCorrect: true
+
+Layout/EndOfLine:
+  Enabled: true
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: true
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: true
+  EnforcedStyle: only_before
+
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: true
+
+# 通常のクラス定義では、本文の周りに空行を入れない
+Layout/EmptyLinesAroundClassBody:
+  Enabled: true
+
+# 通常のメソッド定義では、本文の周りに空行を入れない
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: true
+
+# In a regular module definition, no empty lines around the body.
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: true
+
+# ハッシュに関するRuby >= 1.9の構文を使用します。{ :a => :b } よりも { a: :b } を優先します。
+Style/HashSyntax:
+  Enabled: true
+  EnforcedShorthandSyntax: either
+
+# private や protected の後のメソッド定義は追加のインデントが必要
+Layout/IndentationConsistency:
+  Enabled: true
+  EnforcedStyle: indented_internal_methods
+  Exclude:
+    - '**/*.md'
+
+# インデントにはタブではなく2つのスペースを使用
+Layout/IndentationWidth:
+  Enabled: true
+
+Layout/LeadingCommentSpace:
+  Enabled: true
+
+Layout/SpaceAfterColon:
+  Enabled: true
+
+Layout/SpaceAfterComma:
+  Enabled: true
+
+Layout/SpaceAfterSemicolon:
+  Enabled: true
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+
+Layout/SpaceAroundKeyword:
+  Enabled: true
+
+Layout/SpaceAroundOperators:
+  Enabled: true
+
+Layout/SpaceBeforeComma:
+  Enabled: true
+
+Layout/SpaceBeforeComment:
+  Enabled: true
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+Style/DefWithParentheses:
+  Enabled: true
+
+# パラメータを持つメソッドの定義には括弧が必要
+Style/MethodDefParentheses:
+  Enabled: true
+
+Style/ExplicitBlockArgument:
+  Enabled: true
+
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  Enabled: true
+  EnforcedStyle: always
+  Exclude:
+    - 'actionview/test/**/*.builder'
+    - 'actionview/test/**/*.ruby'
+    - 'actionpack/test/**/*.builder'
+    - 'actionpack/test/**/*.ruby'
+    - 'activestorage/db/migrate/**/*.rb'
+    - 'activestorage/db/update_migrate/**/*.rb'
+    - 'actionmailbox/db/migrate/**/*.rb'
+    - 'actiontext/db/migrate/**/*.rb'
+    - '**/*.md'
 
-# ガード節の提案（難しいので一旦false）
-Style/GuardClause:
-  Enabled: false
+Style/MapToHash:
+  Enabled: true
 
-# 文字列のダブルクォートチェック
+Style/RedundantFreeze:
+  Enabled: true
+
+# Use `foo {}` not `foo{}`.
+Layout/SpaceBeforeBlockBraces:
+  Enabled: true
+
+# Use `foo { bar }` not `foo {bar}`.
+Layout/SpaceInsideBlockBraces:
+  Enabled: true
+  EnforcedStyleForEmptyBraces: space
+
+# Use `{ a: 1 }` not `{a:1}`.
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+
+Layout/SpaceInsideParens:
+  Enabled: true
+
+# リントルールに基づいてクォートの使用をチェック
 Style/StringLiterals:
+  Enabled: true
   EnforcedStyle: double_quotes
 
-# シンボルによる配列の%記法のチェック
-Style/SymbolArray:
-  Enabled: false
-  # EnforcedStyle: brackets
-
-# 文字列による配列の%記法のチェック
-Style/WordArray:
-  Enabled: false
-
-# 変数名に数字を許可
-Naming/VariableNumber:
+# タブを検出し、タブ文字を使用しないでください
+Layout/IndentationStyle:
   Enabled: true
 
-# = と == の指摘
-Lint/AssignmentInCondition:
-  Enabled: false
-
-# メソッド名等の命名の指摘
-Naming/PredicateName:
-  Enabled: false
-
-# 未i18nのチェック（バリデーションエラーメッセージをi18nに登録するのはやや冗長？なためfalse）
-Rails/I18nLocaleTexts:
-  Enabled: false
-
-# before_actionの際の未定義メソッドのチェック
-Rails/LexicallyScopedActionFilter:
+# 空行にはスペースを入れないでください
+Layout/TrailingEmptyLines:
   Enabled: true
+
+# 末尾の空白はありません
+Layout/TrailingWhitespace:
+  Enabled: true
+
+# 文字列リテラルには十分な場合にクォートを使用
+Style/RedundantPercentQ:
+  Enabled: true
+
+Lint/AmbiguousOperator:
+  Enabled: true
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+
+Lint/DuplicateRequire:
+  Enabled: true
+
+Lint/DuplicateMagicComment:
+  Enabled: true
+
+Lint/DuplicateMethods:
+  Enabled: true
+
+Lint/ErbNewArguments:
+  Enabled: true
+
+Lint/EnsureReturn:
+  Enabled: true
+
+Lint/MissingCopEnableDirective:
+  Enabled: true
+
+# Use my_method(my_arg) not my_method( my_arg ) or my_method my_arg.
+Lint/RequireParentheses:
+  Enabled: true
+
+Lint/RedundantCopDisableDirective:
+  Enabled: true
+
+Lint/RedundantCopEnableDirective:
+  Enabled: true
+
+Lint/RedundantStringCoercion:
+  Enabled: true
+
+Lint/RedundantSafeNavigation:
+  Enabled: true
+
+Lint/UriEscapeUnescape:
+  Enabled: true
+
+Lint/UselessAssignment:
+  Enabled: true
+
+Lint/DeprecatedClassMethods:
+  Enabled: true
+
+Lint/InterpolationCheck:
+  Enabled: true
+  Exclude:
+    - '**/test/**/*'
+
+Lint/SafeNavigationChain:
+  Enabled: true
+
+Style/EvalWithLocation:
+  Enabled: true
+  Exclude:
+    - '**/test/**/*'
+
+Style/ParenthesesAroundCondition:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+Style/RedundantBegin:
+  Enabled: true
+
+Style/RedundantReturn:
+  Enabled: true
+  AllowMultipleReturnValues: true
+
+Style/RedundantRegexpEscape:
+  Enabled: true
+
+Style/Semicolon:
+  Enabled: true
+  AllowAsExpressionSeparator: true
+
+# Prefer Foo.method over Foo::method
+Style/ColonMethodCall:
+  Enabled: true
+
+Style/TrivialAccessors:
+  Enabled: true
+
+# Prefer a = b || c over a = b ? b : c
+Style/RedundantCondition:
+  Enabled: true
+
+Style/RedundantDoubleSplatHashBraces:
+  Enabled: true
+
+Style/OpenStructUse:
+  Enabled: true
+
+Style/ArrayIntersect:
+  Enabled: true
+
+Performance/BindCall:
+  Enabled: true
+
+Performance/FlatMap:
+  Enabled: true
+
+Performance/MapCompact:
+  Enabled: true
+
+Performance/SelectMap:
+  Enabled: true
+
+Performance/RedundantMerge:
+  Enabled: true
+
+Performance/StartWith:
+  Enabled: true
+
+Performance/EndWith:
+  Enabled: true
+
+Performance/RegexpMatch:
+  Enabled: true
+
+Performance/ReverseEach:
+  Enabled: true
+
+Performance/StringReplacement:
+  Enabled: true
+
+Performance/DeletePrefix:
+  Enabled: true
+
+Performance/DeleteSuffix:
+  Enabled: true
+
+Performance/InefficientHashSearch:
+  Enabled: true
+
+Performance/ConstantRegexp:
+  Enabled: true
+
+Performance/RedundantStringChars:
+  Enabled: true
+
+Performance/StringInclude:
+  Enabled: true
+
+Minitest/AssertPredicate:
+  Enabled: true
+
+Minitest/AssertRaisesWithRegexpArgument:
+  Enabled: true
+
+Minitest/AssertWithExpectedArgument:
+  Enabled: true
+
+Minitest/LiteralAsActualArgument:
+  Enabled: true
+
+Minitest/NonExecutableTestMethod:
+  Enabled: true
+
+Minitest/SkipEnsure:
+  Enabled: true
+
+Minitest/UnreachableAssertion:
+  Enabled: true
+
+Markdown:
+  # Markdownファイルの構文をチェックします
+  WarnInvalid: true
+  # コードブロックの自動検出を無効にします
+  Autodetect: false

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 ruby "3.2.4"
@@ -40,12 +42,21 @@ gem "active_model_serializers"
 
 gem "dotenv-rails", groups: [:development, :test]
 
+group :rubocop do
+  gem "rubocop", ">= 1.25.1", require: false
+  gem "rubocop-minitest", require: false
+  gem "rubocop-packaging", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
+  gem "rubocop-md", require: false
+
+  # This gem is used in Railties tests so it must be a development dependency.
+  gem "rubocop-rails-omakase", require: false
+end
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows]
-  gem "rubocop", require: false
-  gem "rubocop-performance", require: false
-  gem "rubocop-rails", require: false
 end
 
 group :development do

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -214,6 +214,13 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.31.3)
       parser (>= 3.3.1.0)
+    rubocop-md (1.2.2)
+      rubocop (>= 1.0)
+    rubocop-minitest (0.35.0)
+      rubocop (>= 1.61, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-packaging (0.5.2)
+      rubocop (>= 1.33, < 2.0)
     rubocop-performance (1.21.0)
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
@@ -222,6 +229,11 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-rails-omakase (1.0.0)
+      rubocop
+      rubocop-minitest
+      rubocop-performance
+      rubocop-rails
     ruby-progressbar (1.13.0)
     stringio (3.1.0)
     thor (1.3.1)
@@ -250,9 +262,13 @@ DEPENDENCIES
   rack-cors
   rails (~> 7.1.3, >= 7.1.3.2)
   redis (>= 4.0.1)
-  rubocop
+  rubocop (>= 1.25.1)
+  rubocop-md
+  rubocop-minitest
+  rubocop-packaging
   rubocop-performance
   rubocop-rails
+  rubocop-rails-omakase
   tzinfo-data
 
 RUBY VERSION

--- a/backend/Rakefile
+++ b/backend/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/backend/app/channels/application_cable/channel.rb
+++ b/backend/app/channels/application_cable/channel.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
   end

--- a/backend/app/channels/application_cable/connection.rb
+++ b/backend/app/channels/application_cable/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
   end

--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,25 +1,26 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::API
   before_action :authenticate_request
 
   private
+    def authenticate_request
+      header = request.headers["Authorization"]
+      header = header.split.last if header
 
-  def authenticate_request
-    header = request.headers["Authorization"]
-    header = header.split.last if header
+      return render json: { errors: "No token provided" }, status: :forbidden unless header
 
-    return render json: { errors: "No token provided" }, status: :forbidden unless header
-
-    begin
-      @decoded = JWT.decode(header, Rails.application.credentials.jwt_secret_key, true, { algorithm: "HS256" })[0]
-      @current_user = User.find(@decoded["id"])
-    rescue JWT::DecodeError => e
-      render json: { errors: "Invalid token: #{e.message}" }, status: :unauthorized
-    rescue ActiveRecord::RecordNotFound
-      render json: { errors: "User not found" }, status: :unauthorized
-    rescue JWT::ExpiredSignature
-      render json: { errors: "Token has expired" }, status: :unauthorized
-    rescue JWT::VerificationError
-      render json: { errors: "Token verification failed" }, status: :unauthorized
+      begin
+        @decoded = JWT.decode(header, Rails.application.credentials.jwt_secret_key, true, { algorithm: "HS256" })[0]
+        @current_user = User.find(@decoded["id"])
+      rescue JWT::DecodeError => e
+        render json: { errors: "Invalid token: #{e.message}" }, status: :unauthorized
+      rescue ActiveRecord::RecordNotFound
+        render json: { errors: "User not found" }, status: :unauthorized
+      rescue JWT::ExpiredSignature
+        render json: { errors: "Token has expired" }, status: :unauthorized
+      rescue JWT::VerificationError
+        render json: { errors: "Token verification failed" }, status: :unauthorized
+      end
     end
-  end
 end

--- a/backend/app/controllers/sessions_controller.rb
+++ b/backend/app/controllers/sessions_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SessionsController < ApplicationController
   skip_before_action :authenticate_request, only: [:create]
 

--- a/backend/app/controllers/teams_controller.rb
+++ b/backend/app/controllers/teams_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TeamsController < ApplicationController
   before_action :set_team, only: [:show, :update, :destroy]
 
@@ -38,12 +40,11 @@ class TeamsController < ApplicationController
   end
 
   private
+    def set_team
+      @team = @current_user.teams.find(params[:id])
+    end
 
-  def set_team
-    @team = @current_user.teams.find(params[:id])
-  end
-
-  def team_params
-    params.require(:team).permit(:name, :details, :profile_photo, :background_photo)
-  end
+    def team_params
+      params.require(:team).permit(:name, :details, :profile_photo, :background_photo)
+    end
 end

--- a/backend/app/controllers/users_controller.rb
+++ b/backend/app/controllers/users_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UsersController < ApplicationController
   # 新規ユーザーの作成時に認証が不要
   skip_before_action :authenticate_request, only: [:create]
@@ -17,17 +19,16 @@ class UsersController < ApplicationController
   end
 
     private
+      def user_params
+        params.required(:user).permit(:email, :password, :user_name, :profile_photo, :background_photo, :bio)
+      end
 
-    def user_params
-      params.required(:user).permit(:email, :password, :user_name, :profile_photo, :background_photo, :bio)
-    end
-
-    def user_errors
-      errors = []
-      errors << "Email has already been taken" if @user.errors[:email].present?
-      errors << "Password is too short (minimum is 6 characters)" if @user.errors[:password].present?
-      errors << "User name is required" if @user.errors[:user_name].present?
-      # 他のエラーチェックも追加可能
-      errors
-    end
+      def user_errors
+        errors = []
+        errors << "Email has already been taken" if @user.errors[:email].present?
+        errors << "Password is too short (minimum is 6 characters)" if @user.errors[:password].present?
+        errors << "User name is required" if @user.errors[:user_name].present?
+        # 他のエラーチェックも追加可能
+        errors
+      end
 end

--- a/backend/app/jobs/application_job.rb
+++ b/backend/app/jobs/application_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked

--- a/backend/app/mailers/application_mailer.rb
+++ b/backend/app/mailers/application_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationMailer < ActionMailer::Base
   default from: "from@example.com"
   layout "mailer"

--- a/backend/app/models/application_record.rb
+++ b/backend/app/models/application_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 end

--- a/backend/app/models/team.rb
+++ b/backend/app/models/team.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Team < ApplicationRecord
   belongs_to :user
 

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User < ApplicationRecord
   has_secure_password
 

--- a/backend/app/serializers/user_serializer.rb
+++ b/backend/app/serializers/user_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UserSerializer < ActiveModel::Serializer
   attributes :id, :email, :user_name, :profile_photo, :background_photo, :bio
 end

--- a/backend/bin/bundle
+++ b/backend/bin/bundle
@@ -30,7 +30,7 @@ m = Module.new do
       if update_index && update_index.succ == i && a =~ Gem::Version::ANCHORED_VERSION_PATTERN
         bundler_version = a
       end
-      next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/
+      next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/o
       bundler_version = $1
       update_index = i
     end
@@ -56,7 +56,7 @@ m = Module.new do
   def lockfile_version
     return unless File.file?(lockfile)
     lockfile_contents = File.read(lockfile)
-    return unless lockfile_contents =~ /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/
+    return unless lockfile_contents =~ /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/o
     Regexp.last_match(1)
   end
 

--- a/backend/bin/rails
+++ b/backend/bin/rails
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 APP_PATH = File.expand_path("../config/application", __dir__)
 require_relative "../config/boot"
 require "rails/commands"

--- a/backend/bin/rake
+++ b/backend/bin/rake
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require_relative "../config/boot"
 require "rake"
 Rake.application.run

--- a/backend/bin/setup
+++ b/backend/bin/setup
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require "fileutils"
 
 # path to your application root.

--- a/backend/config.ru
+++ b/backend/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
 require_relative "config/environment"

--- a/backend/config/application.rb
+++ b/backend/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "boot"
 
 require "rails/all"

--- a/backend/config/boot.rb
+++ b/backend/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/backend/config/environment.rb
+++ b/backend/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require_relative "application"
 

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do

--- a/backend/config/environments/test.rb
+++ b/backend/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/integer/time"
 
 # The test environment is used exclusively to run your application's

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins "*"

--- a/backend/config/initializers/filter_parameter_logging.rb
+++ b/backend/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.

--- a/backend/config/initializers/inflections.rb
+++ b/backend/config/initializers/inflections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/backend/config/puma.rb
+++ b/backend/config/puma.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This configuration file will be evaluated by Puma. The top-level methods that
 # are invoked here are part of Puma's configuration DSL. For more information
 # about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   post "/signup", to: "users#create"
   post "/login",  to: "sessions#create"

--- a/backend/db/migrate/20240501135006_create_users.rb
+++ b/backend/db/migrate/20240501135006_create_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateUsers < ActiveRecord::Migration[7.1]
   def change
     create_table :users do |t|

--- a/backend/db/migrate/20240502111817_create_teams.rb
+++ b/backend/db/migrate/20240502111817_create_teams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateTeams < ActiveRecord::Migration[7.1]
   def change
     create_table :teams do |t|

--- a/backend/db/migrate/20240502121515_add_photos_to_teams.rb
+++ b/backend/db/migrate/20240502121515_add_photos_to_teams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPhotosToTeams < ActiveRecord::Migration[7.1]
   def change
     add_column :teams, :profile_photo, :string

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 # db/seeds.rb
 User.create!(
-    email: 'user@example.com',
-    password_digest: BCrypt::Password.create('password'),
-    user_name: 'Demo User',
-    bio: 'This is a demo user.'
-)
+    email: "user@example.com",
+    password_digest: BCrypt::Password.create("password"),
+    user_name: "Demo User",
+    bio: "This is a demo user."
+  )

--- a/backend/test/channels/application_cable/connection_test.rb
+++ b/backend/test/channels/application_cable/connection_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 module ApplicationCable

--- a/backend/test/controllers/sessions_controller_test.rb
+++ b/backend/test/controllers/sessions_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class SessionsControllerTest < ActionDispatch::IntegrationTest

--- a/backend/test/controllers/users_controller_test.rb
+++ b/backend/test/controllers/users_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class UsersControllerTest < ActionDispatch::IntegrationTest

--- a/backend/test/models/team_test.rb
+++ b/backend/test/models/team_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class TeamTest < ActiveSupport::TestCase

--- a/backend/test/models/user_test.rb
+++ b/backend/test/models/user_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class UserTest < ActiveSupport::TestCase

--- a/backend/test/test_helper.rb
+++ b/backend/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"


### PR DESCRIPTION
# RuboCop 設定ファイル

この設定ファイルは RuboCop を使用して Ruby プロジェクトを静的解析するためのものです。以下は主な設定項目です。

## require:

- rubocop-minitest
- rubocop-packaging
- rubocop-performance
- rubocop-rails
- rubocop-md

## AllCops:

- `TargetRubyVersion`: 解析対象の Ruby バージョンを指定します。
- `DisabledByDefault`: デフォルトで有効になっているルールを無効にし、明示的に設定したルールのみ有効にします。
- `SuggestExtensions`: RuboCop の拡張機能の提案を有効にするかどうかを指定します。
- `Exclude`: ルールの適用対象から除外するファイルやディレクトリを指定します。

## Performance:

- パフォーマンス関連のルールを除外するファイルやディレクトリを指定します。

## Rails ルール:

- Rails フレームワーク特有のルールを適用します。

## Style:

- コードのスタイルに関するルールを設定します。

## Layout:

- コードのレイアウトに関するルールを設定します。

## Lint:

- コードの品質に関するルールを設定します。

## Minitest:

- Minitest テストフレームワークに関するルールを設定します。

## Markdown:

- Markdown ファイルに対するルールを設定します。構文チェックやコードブロックの自動検出などが含まれます。
