### PR TITLE
修正: GitHub Actions ワークフローの環境変数設定方法の改善

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
-          MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
+          MYSQL_DATABASE: ${{ secrets.MYSQL_TEST_DATABASE }}
 
     steps:
     - uses: actions/checkout@v2
@@ -31,20 +31,20 @@ jobs:
       run: |
         echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> $GITHUB_ENV
         echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" >> $GITHUB_ENV
-        echo "MYSQL_DATABASE=${{ secrets.MYSQL_DATABASE }}" >> $GITHUB_ENV
+        echo "MYSQL_DATABASE=${{ secrets.MYSQL_TEST_DATABASE }}" >> $GITHUB_ENV
         echo "MYSQL_USER=${{ secrets.MYSQL_USER }}" >> $GITHUB_ENV
         echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> $GITHUB_ENV
         echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> $GITHUB_ENV
 
     - name: Create .env file
       run: |
-        echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" > .env
-        echo "MYSQL_DATABASE=${{ secrets.MYSQL_DATABASE }}" >> .env
-        echo "MYSQL_USER=${{ secrets.MYSQL_USER }}" >> .env
-        echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> .env
-        echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> .env
-        echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> .env
-        echo "NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_API_BASE_URL }}" >> .env
+        echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" > backend/.env
+        echo "MYSQL_DATABASE=${{ secrets.MYSQL_TEST_DATABASE }}" >> backend/.env
+        echo "MYSQL_USER=${{ secrets.MYSQL_USER }}" >> backend/.env
+        echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> backend/.env
+        echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> backend/.env
+        echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> backend/.env
+        echo "NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_API_BASE_URL }}" >> backend/.env
 
     - name: Install dependencies
       run: |
@@ -53,18 +53,27 @@ jobs:
         bundle install --jobs 4 --retry 3
 
     - name: Build Docker image
-      run: docker-compose --env-file .env build
+      env:
+        RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+        MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+        MYSQL_DATABASE: ${{ secrets.MYSQL_TEST_DATABASE }}
+        MYSQL_USER: ${{ secrets.MYSQL_USER }}
+        MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
+        MYSQL_HOST: ${{ secrets.MYSQL_HOST }}
+      run: |
+        cd backend
+        docker-compose build
 
     - name: Set up database
       run: |
         cp backend/config/database.yml.ci backend/config/database.yml
-        docker-compose run --rm -e RAILS_ENV=test --env-file .env backend rake db:create db:schema:load
+        docker-compose run --rm -e RAILS_ENV=test --env-file backend/.env backend rake db:create db:schema:load
 
     - name: Run RuboCop
-      run: docker-compose run --rm backend bundle exec rubocop
+      run: docker-compose run --rm --env-file backend/.env backend bundle exec rubocop
 
     - name: Run tests
-      run: docker-compose run --rm -e RAILS_ENV=test --env-file .env backend bundle exec rspec
+      run: docker-compose run --rm -e RAILS_ENV=test --env-file backend/.env backend bundle exec rspec
 
     - name: Clean up
       run: docker-compose down --volumes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
-          MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
+          MYSQL_DATABASE: ${{ secrets.MYSQL_TEST_DATABASE }}
 
     steps:
     - uses: actions/checkout@v2
@@ -27,8 +27,16 @@ jobs:
       with:
         ruby-version: 3.2
 
+    - name: Set up environment variables
+      run: |
+        echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> $GITHUB_ENV
+        echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" >> $GITHUB_ENV
+        echo "MYSQL_DATABASE=${{ secrets.MYSQL_TEST_DATABASE }}" >> $GITHUB_ENV
+        echo "MYSQL_USER=${{ secrets.MYSQL_USER }}" >> $GITHUB_ENV
+        echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> $GITHUB_ENV
+        echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> $GITHUB_ENV
+
     - name: Install dependencies
-      working-directory: backend
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3
@@ -39,15 +47,13 @@ jobs:
     - name: Set up database
       run: |
         cp backend/config/database.yml.ci backend/config/database.yml
-        docker-compose run --rm -e RAILS_ENV=test --env-file .env backend rake db:create db:schema:load
-      env:
-        RAILS_ENV: test
+        docker-compose run --rm -e RAILS_ENV=test backend rake db:create db:schema:load
 
     - name: Run RuboCop
       run: docker-compose run --rm backend bundle exec rubocop
 
     - name: Run tests
-      run: docker-compose run --rm -e RAILS_ENV=test --env-file .env backend bundle exec rspec
+      run: docker-compose run --rm -e RAILS_ENV=test backend bundle exec rspec
 
     - name: Clean up
       run: docker-compose down --volumes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
-          MYSQL_DATABASE: ${{ secrets.MYSQL_TEST_DATABASE }}
+          MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
 
     steps:
     - uses: actions/checkout@v2
@@ -31,13 +31,24 @@ jobs:
       run: |
         echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> $GITHUB_ENV
         echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" >> $GITHUB_ENV
-        echo "MYSQL_DATABASE=${{ secrets.MYSQL_TEST_DATABASE }}" >> $GITHUB_ENV
+        echo "MYSQL_DATABASE=${{ secrets.MYSQL_DATABASE }}" >> $GITHUB_ENV
         echo "MYSQL_USER=${{ secrets.MYSQL_USER }}" >> $GITHUB_ENV
         echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> $GITHUB_ENV
         echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> $GITHUB_ENV
 
+    - name: Create .env file
+      run: |
+        echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" > .env
+        echo "MYSQL_DATABASE=${{ secrets.MYSQL_DATABASE }}" >> .env
+        echo "MYSQL_USER=${{ secrets.MYSQL_USER }}" >> .env
+        echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> .env
+        echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> .env
+        echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> .env
+        echo "NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_API_BASE_URL }}" >> .env
+
     - name: Install dependencies
       run: |
+        cd backend
         gem install bundler
         bundle install --jobs 4 --retry 3
 
@@ -47,13 +58,13 @@ jobs:
     - name: Set up database
       run: |
         cp backend/config/database.yml.ci backend/config/database.yml
-        docker-compose run --rm -e RAILS_ENV=test backend rake db:create db:schema:load
+        docker-compose run --rm -e RAILS_ENV=test --env-file .env backend rake db:create db:schema:load
 
     - name: Run RuboCop
       run: docker-compose run --rm backend bundle exec rubocop
 
     - name: Run tests
-      run: docker-compose run --rm -e RAILS_ENV=test backend bundle exec rspec
+      run: docker-compose run --rm -e RAILS_ENV=test --env-file .env backend bundle exec rspec
 
     - name: Clean up
       run: docker-compose down --volumes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Build Docker image
       run: |
         cd backend
-        docker-compose --env-file .env build
+        docker-compose build
 
     - name: Set up database
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,16 +36,15 @@ jobs:
         echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> $GITHUB_ENV
         echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> $GITHUB_ENV
 
-    - name: Create .env file
+    - name: Create .env.ci file
       run: |
-        echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" > .env
-        echo "MYSQL_DATABASE=${{ secrets.MYSQL_TEST_DATABASE }}" >> .env
-        echo "MYSQL_USER=${{ secrets.MYSQL_USER }}" >> .env
-        echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> .env
-        echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> .env
-        echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> .env
-        echo "NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_API_BASE_URL }}" >> .env
-        mv .env backend/.env
+        echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" > backend/.env.ci
+        echo "MYSQL_DATABASE=${{ secrets.MYSQL_TEST_DATABASE }}" >> backend/.env.ci
+        echo "MYSQL_USER=${{ secrets.MYSQL_USER }}" >> backend/.env.ci
+        echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> backend/.env.ci
+        echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> backend/.env.ci
+        echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> backend/.env.ci
+        echo "NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_API_BASE_URL }}" >> backend/.env.ci
 
     - name: Install dependencies
       run: |
@@ -56,18 +55,19 @@ jobs:
     - name: Build Docker image
       run: |
         cd backend
-        docker-compose --env-file .env build
+        docker-compose build
 
     - name: Set up database
       run: |
-        cp backend/config/database.yml.ci backend/config/database.yml
-        docker-compose run --rm -e RAILS_ENV=test --env-file backend/.env backend rake db:create db:schema:load
+        cd backend
+        cp config/database.yml.ci config/database.yml
+        docker-compose run --rm -e RAILS_ENV=test --env-file .env.ci backend rake db:create db:schema:load
 
     - name: Run RuboCop
-      run: docker-compose run --rm --env-file backend/.env backend bundle exec rubocop
+      run: docker-compose run --rm --env-file backend/.env.ci backend bundle exec rubocop
 
     - name: Run tests
-      run: docker-compose run --rm -e RAILS_ENV=test --env-file backend/.env backend bundle exec rspec
+      run: docker-compose run --rm -e RAILS_ENV=test --env-file backend/.env.ci backend bundle exec rspec
 
     - name: Clean up
       run: docker-compose down --volumes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> $GITHUB_ENV
         echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> $GITHUB_ENV
 
-    - name: Create environment variables file
+    - name: Create .env file
       run: |
         echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" > backend/.env
         echo "MYSQL_DATABASE=${{ secrets.MYSQL_TEST_DATABASE }}" >> backend/.env
@@ -44,6 +44,7 @@ jobs:
         echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> backend/.env
         echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> backend/.env
         echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> backend/.env
+        echo "NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_API_BASE_URL }}" >> backend/.env
 
     - name: Install dependencies
       run: |
@@ -52,9 +53,7 @@ jobs:
         bundle install --jobs 4 --retry 3
 
     - name: Build Docker image
-      run: |
-        cd backend
-        docker-compose build
+      run: cd backend && docker-compose build
 
     - name: Set up database
       run: |
@@ -63,17 +62,10 @@ jobs:
         docker-compose run --rm -e RAILS_ENV=test --env-file .env backend rake db:create db:schema:load
 
     - name: Run RuboCop
-      run: |
-        cd backend
-        docker-compose run --rm --env-file .env backend bundle exec rubocop
+      run: cd backend && docker-compose run --rm --env-file .env backend bundle exec rubocop
 
     - name: Run tests
-      run: |
-        cd backend
-        docker-compose run --rm --env-file .env -e RAILS_ENV=test backend bundle exec rspec
+      run: cd backend && docker-compose run --rm -e RAILS_ENV=test --env-file .env backend bundle exec rspec
 
     - name: Clean up
-      run: |
-        cd backend
-        docker-compose down --volumes
-
+      run: cd backend && docker-compose down --volumes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         bundle install --jobs 4 --retry 3
 
     - name: Build Docker image
-      run: docker-compose build
+      run: docker-compose --env-file .env build
 
     - name: Set up database
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,13 +38,14 @@ jobs:
 
     - name: Create .env file
       run: |
-        echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" > backend/.env
-        echo "MYSQL_DATABASE=${{ secrets.MYSQL_TEST_DATABASE }}" >> backend/.env
-        echo "MYSQL_USER=${{ secrets.MYSQL_USER }}" >> backend/.env
-        echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> backend/.env
-        echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> backend/.env
-        echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> backend/.env
-        echo "NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_API_BASE_URL }}" >> backend/.env
+        echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" > .env
+        echo "MYSQL_DATABASE=${{ secrets.MYSQL_TEST_DATABASE }}" >> .env
+        echo "MYSQL_USER=${{ secrets.MYSQL_USER }}" >> .env
+        echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> .env
+        echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> .env
+        echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> .env
+        echo "NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_API_BASE_URL }}" >> .env
+        mv .env backend/.env
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,15 +36,15 @@ jobs:
         echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> $GITHUB_ENV
         echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> $GITHUB_ENV
 
-    - name: Create .env.ci file
+    - name: Create .env file
       run: |
-        echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" > backend/.env.ci
-        echo "MYSQL_DATABASE=${{ secrets.MYSQL_TEST_DATABASE }}" >> backend/.env.ci
-        echo "MYSQL_USER=${{ secrets.MYSQL_USER }}" >> backend/.env.ci
-        echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> backend/.env.ci
-        echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> backend/.env.ci
-        echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> backend/.env.ci
-        echo "NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_API_BASE_URL }}" >> backend/.env.ci
+        echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" > backend/.env
+        echo "MYSQL_DATABASE=${{ secrets.MYSQL_TEST_DATABASE }}" >> backend/.env
+        echo "MYSQL_USER=${{ secrets.MYSQL_USER }}" >> backend/.env
+        echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> backend/.env
+        echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> backend/.env
+        echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> backend/.env
+        echo "NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_API_BASE_URL }}" >> backend/.env
 
     - name: Install dependencies
       run: |
@@ -53,21 +53,18 @@ jobs:
         bundle install --jobs 4 --retry 3
 
     - name: Build Docker image
-      run: |
-        cd backend
-        docker-compose build
+      run: docker-compose --env-file backend/.env build
 
     - name: Set up database
       run: |
-        cd backend
-        cp config/database.yml.ci config/database.yml
-        docker-compose run --rm -e RAILS_ENV=test --env-file .env.ci backend rake db:create db:schema:load
+        cp backend/config/database.yml.ci backend/config/database.yml
+        docker-compose run --rm -e RAILS_ENV=test --env-file backend/.env backend rake db:create db:schema:load
 
     - name: Run RuboCop
-      run: docker-compose run --rm --env-file backend/.env.ci backend bundle exec rubocop
+      run: docker-compose run --rm --env-file backend/.env backend bundle exec rubocop
 
     - name: Run tests
-      run: docker-compose run --rm -e RAILS_ENV=test --env-file backend/.env.ci backend bundle exec rspec
+      run: docker-compose run --rm -e RAILS_ENV=test --env-file backend/.env backend bundle exec rspec
 
     - name: Clean up
       run: docker-compose down --volumes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> $GITHUB_ENV
         echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> $GITHUB_ENV
 
-    - name: Create .env file
+    - name: Create environment variables file
       run: |
         echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" > backend/.env
         echo "MYSQL_DATABASE=${{ secrets.MYSQL_TEST_DATABASE }}" >> backend/.env
@@ -44,7 +44,6 @@ jobs:
         echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> backend/.env
         echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> backend/.env
         echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> backend/.env
-        echo "NEXT_PUBLIC_API_BASE_URL=${{ secrets.NEXT_PUBLIC_API_BASE_URL }}" >> backend/.env
 
     - name: Install dependencies
       run: |
@@ -53,19 +52,28 @@ jobs:
         bundle install --jobs 4 --retry 3
 
     - name: Build Docker image
-      run: docker-compose --env-file backend/.env build
+      run: |
+        cd backend
+        docker-compose build
 
     - name: Set up database
       run: |
-        cp backend/config/database.yml.ci backend/config/database.yml
-        docker-compose run --rm -e RAILS_ENV=test --env-file backend/.env backend rake db:create db:schema:load
+        cd backend
+        cp config/database.yml.ci config/database.yml
+        docker-compose run --rm -e RAILS_ENV=test --env-file .env backend rake db:create db:schema:load
 
     - name: Run RuboCop
-      run: docker-compose run --rm --env-file backend/.env backend bundle exec rubocop
+      run: |
+        cd backend
+        docker-compose run --rm --env-file .env backend bundle exec rubocop
 
     - name: Run tests
-      run: docker-compose run --rm -e RAILS_ENV=test --env-file backend/.env backend bundle exec rspec
+      run: |
+        cd backend
+        docker-compose run --rm --env-file .env -e RAILS_ENV=test backend bundle exec rspec
 
     - name: Clean up
-      run: docker-compose down --volumes
+      run: |
+        cd backend
+        docker-compose down --volumes
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
-    branches: [main]
+    branches: [ main ]
 
 jobs:
   build:
@@ -12,12 +12,14 @@ jobs:
 
     services:
       redis:
-        image: redis
+        image: redis:7.2.5
       db:
         image: mysql:8.0
         env:
           MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
-          MYSQL_DATABASE: ${{ secrets.MYSQL_TEST_DATABASE }}
+          MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
+          MYSQL_USER: ${{ secrets.MYSQL_USER }}
+          MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
 
     steps:
     - uses: actions/checkout@v2
@@ -31,7 +33,7 @@ jobs:
       run: |
         echo "RAILS_MASTER_KEY=${{ secrets.RAILS_MASTER_KEY }}" >> $GITHUB_ENV
         echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" >> $GITHUB_ENV
-        echo "MYSQL_DATABASE=${{ secrets.MYSQL_TEST_DATABASE }}" >> $GITHUB_ENV
+        echo "MYSQL_DATABASE=${{ secrets.MYSQL_DATABASE }}" >> $GITHUB_ENV
         echo "MYSQL_USER=${{ secrets.MYSQL_USER }}" >> $GITHUB_ENV
         echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> $GITHUB_ENV
         echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> $GITHUB_ENV
@@ -39,7 +41,7 @@ jobs:
     - name: Create .env file
       run: |
         echo "MYSQL_ROOT_PASSWORD=${{ secrets.MYSQL_ROOT_PASSWORD }}" > backend/.env
-        echo "MYSQL_DATABASE=${{ secrets.MYSQL_TEST_DATABASE }}" >> backend/.env
+        echo "MYSQL_DATABASE=${{ secrets.MYSQL_DATABASE }}" >> backend/.env
         echo "MYSQL_USER=${{ secrets.MYSQL_USER }}" >> backend/.env
         echo "MYSQL_PASSWORD=${{ secrets.MYSQL_PASSWORD }}" >> backend/.env
         echo "MYSQL_HOST=${{ secrets.MYSQL_HOST }}" >> backend/.env
@@ -59,19 +61,18 @@ jobs:
 
     - name: Set up database
       run: |
-        cd backend
-        cp config/database.yml.ci config/database.yml
-        docker-compose run --rm -e RAILS_ENV=test --env-file .env backend rake db:create db:schema:load
+        cp backend/config/database.yml.ci backend/config/database.yml
+        docker-compose run --rm -e RAILS_ENV=test --env-file backend/.env backend rake db:create db:schema:load
 
     - name: Run RuboCop
       run: |
         cd backend
-        docker-compose run --rm --env-file .env backend bundle exec rubocop
+        docker-compose run --rm backend bundle exec rubocop
 
     - name: Run tests
       run: |
         cd backend
-        docker-compose run --rm -e RAILS_ENV=test --env-file .env backend bundle exec rspec
+        docker-compose run --rm -e RAILS_ENV=test --env-file backend/.env backend bundle exec rspec
 
     - name: Clean up
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,16 +53,7 @@ jobs:
         bundle install --jobs 4 --retry 3
 
     - name: Build Docker image
-      env:
-        RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-        MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
-        MYSQL_DATABASE: ${{ secrets.MYSQL_TEST_DATABASE }}
-        MYSQL_USER: ${{ secrets.MYSQL_USER }}
-        MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
-        MYSQL_HOST: ${{ secrets.MYSQL_HOST }}
-      run: |
-        cd backend
-        docker-compose build
+      run: docker-compose --env-file backend/.env build
 
     - name: Set up database
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
@@ -53,7 +53,9 @@ jobs:
         bundle install --jobs 4 --retry 3
 
     - name: Build Docker image
-      run: cd backend && docker-compose build
+      run: |
+        cd backend
+        docker-compose --env-file .env build
 
     - name: Set up database
       run: |
@@ -62,10 +64,16 @@ jobs:
         docker-compose run --rm -e RAILS_ENV=test --env-file .env backend rake db:create db:schema:load
 
     - name: Run RuboCop
-      run: cd backend && docker-compose run --rm --env-file .env backend bundle exec rubocop
+      run: |
+        cd backend
+        docker-compose run --rm --env-file .env backend bundle exec rubocop
 
     - name: Run tests
-      run: cd backend && docker-compose run --rm -e RAILS_ENV=test --env-file .env backend bundle exec rspec
+      run: |
+        cd backend
+        docker-compose run --rm -e RAILS_ENV=test --env-file .env backend bundle exec rspec
 
     - name: Clean up
-      run: cd backend && docker-compose down --volumes
+      run: |
+        cd backend
+        docker-compose down --volumes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,9 @@ jobs:
         bundle install --jobs 4 --retry 3
 
     - name: Build Docker image
-      run: docker-compose --env-file backend/.env build
+      run: |
+        cd backend
+        docker-compose --env-file .env build
 
     - name: Set up database
       run: |


### PR DESCRIPTION
### プルリクエスト概要

このプルリクエストでは、GitHub Actions ワークフロー内で環境変数の設定方法を改善し、`.env`ファイルが見つからないというエラーを修正します。具体的には、環境変数をDocker Composeコマンドに直接渡すように変更しました。

### 変更内容

- `.github/workflows/ci.yml` の修正
  - 環境変数をGitHub Secretsから取得し、`.env`ファイルを生成
  - Docker Composeコマンドを実行する前にディレクトリを移動し、`.env`ファイルを使用
- `.env`ファイルの生成手順を追加

### 詳細

以下の手順でワークフローを修正しました：

1. **Set up environment variables** ステップで、GitHub Secretsから環境変数を設定。
2. **Create environment variables file** ステップで、環境変数を`.env`ファイルに書き込み。この`.env`ファイルは`backend`ディレクトリ内に作成される。
3. **各Docker Composeコマンド** で、`cd backend`を使用してディレクトリを移動し、`.env`ファイルを使用してコマンドを実行。
