### PR TITLE
modify_team destroy

### DIFF
--- a/backend/app/models/conversation.rb
+++ b/backend/app/models/conversation.rb
@@ -2,7 +2,7 @@
 
 class Conversation < ApplicationRecord
   belongs_to :recruitment
-  has_many :messages
+  has_many :messages, dependent: :destroy
   has_many :applications, through: :recruitment
   has_and_belongs_to_many :users  # 追加：ユーザーと多対多の関連を定義
 

--- a/backend/app/models/recruitment.rb
+++ b/backend/app/models/recruitment.rb
@@ -3,7 +3,7 @@
 class Recruitment < ApplicationRecord
   has_many :applications, dependent: :destroy
   has_many :favorites, dependent: :destroy
-  has_many :conversations
+  has_many :conversations, dependent: :destroy
   belongs_to :team
 
   validates :title, presence: true

--- a/backend/app/models/team.rb
+++ b/backend/app/models/team.rb
@@ -2,7 +2,10 @@
 
 class Team < ApplicationRecord
   belongs_to :user
-  has_many :recruitments
+  has_many :recruitments, dependent: :destroy
+  has_many :applications, through: :recruitments, dependent: :destroy
+  has_many :favorites, through: :recruitments, dependent: :destroy
+  has_many :conversations, through: :recruitments, dependent: :destroy
 
   mount_uploader :profile_photo, ProfilePhotoUploader
 

--- a/backend/db/migrate/20240728130344_add_cascade_to_team_associations.rb
+++ b/backend/db/migrate/20240728130344_add_cascade_to_team_associations.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 class AddCascadeToTeamAssociations < ActiveRecord::Migration[7.1]
   def change
     remove_foreign_key :recruitments, :teams
     remove_foreign_key :teams, :users
-    
+
     add_foreign_key :recruitments, :teams, on_delete: :cascade
     add_foreign_key :teams, :users, on_delete: :cascade
 

--- a/backend/db/migrate/20240728130344_add_cascade_to_team_associations.rb
+++ b/backend/db/migrate/20240728130344_add_cascade_to_team_associations.rb
@@ -1,0 +1,24 @@
+class AddCascadeToTeamAssociations < ActiveRecord::Migration[7.1]
+  def change
+    remove_foreign_key :recruitments, :teams
+    remove_foreign_key :teams, :users
+    
+    add_foreign_key :recruitments, :teams, on_delete: :cascade
+    add_foreign_key :teams, :users, on_delete: :cascade
+
+    remove_foreign_key :applications, :recruitments
+    add_foreign_key :applications, :recruitments, on_delete: :cascade
+
+    remove_foreign_key :favorites, :recruitments
+    add_foreign_key :favorites, :recruitments, on_delete: :cascade
+
+    remove_foreign_key :conversations, :recruitments
+    add_foreign_key :conversations, :recruitments, on_delete: :cascade
+
+    remove_foreign_key :conversations_users, :conversations
+    add_foreign_key :conversations_users, :conversations, on_delete: :cascade
+
+    remove_foreign_key :messages, :conversations
+    add_foreign_key :messages, :conversations, on_delete: :cascade
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -98,16 +96,16 @@ ActiveRecord::Schema[7.1].define(version: 202407230110000) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
-  add_foreign_key "applications", "recruitments"
+  add_foreign_key "applications", "recruitments", on_delete: :cascade
   add_foreign_key "applications", "users"
-  add_foreign_key "conversations", "recruitments"
-  add_foreign_key "conversations_users", "conversations"
+  add_foreign_key "conversations", "recruitments", on_delete: :cascade
+  add_foreign_key "conversations_users", "conversations", on_delete: :cascade
   add_foreign_key "conversations_users", "users"
-  add_foreign_key "favorites", "recruitments"
+  add_foreign_key "favorites", "recruitments", on_delete: :cascade
   add_foreign_key "favorites", "users"
-  add_foreign_key "messages", "conversations"
+  add_foreign_key "messages", "conversations", on_delete: :cascade
   add_foreign_key "messages", "users", column: "recipient_id"
   add_foreign_key "messages", "users", column: "sender_id"
-  add_foreign_key "recruitments", "teams"
-  add_foreign_key "teams", "users"
+  add_foreign_key "recruitments", "teams", on_delete: :cascade
+  add_foreign_key "teams", "users", on_delete: :cascade
 end


### PR DESCRIPTION
# プルリクエスト: チーム削除時の関連データのカスケード削除機能の追加

## 概要

このプルリクエストでは、チームを削除した際に関連するデータ（募集、会話、メッセージ、応募など）が自動的に削除されるように機能を追加しました。これにより、データベースの一貫性が保たれ、不要なデータが残ることを防ぎます。

## 変更内容

- `teams`テーブルに外部キー制約を追加し、関連するレコードがカスケード削除されるようにマイグレーションを作成しました。
- 各モデルに関連する`dependent: :destroy`オプションを追加しました。

## 変更理由

チームが削除された場合に、そのチームに関連するすべてのデータも削除されるようにすることで、データの整合性を保ち、不要なデータの蓄積を防ぐためです。

## マイグレーションファイルの作成

以下のコマンドでマイグレーションファイルを作成しました：

```ruby
rails generate migration AddCascadeDeleteToTeams
class AddCascadeDeleteToTeams < ActiveRecord::Migration[7.1]
  def change
    remove_foreign_key :recruitments, :teams
    add_foreign_key :recruitments, :teams, on_delete: :cascade

    remove_foreign_key :conversations, :recruitments
    add_foreign_key :conversations, :recruitments, on_delete: :cascade

    remove_foreign_key :applications, :recruitments
    add_foreign_key :applications, :recruitments, on_delete: :cascade

    remove_foreign_key :applications, :users
    add_foreign_key :applications, :users, on_delete: :cascade

    remove_foreign_key :messages, :conversations
    add_foreign_key :messages, :conversations, on_delete: :cascade

    remove_foreign_key :messages, :users, column: :sender_id
    add_foreign_key :messages, :users, column: :sender_id, on_delete: :cascade

    remove_foreign_key :messages, :users, column: :recipient_id
    add_foreign_key :messages, :users, column: :recipient_id, on_delete: :cascade
  end
end
```

## テスト
以下の項目について手動テストを実施しました：

1. チームを削除した際に、関連する募集、会話、メッセージ、応募が自動的に削除されることを確認。
2. データベースに不要なデータが残らないことを確認。

## 注意事項
この変更は既存のデータベースに影響を与えるため、適用前にバックアップを取ることを推奨します。