### PR TITLE
Fix: Only send message on button click

### DIFF
--- a/frontend/src/components/Chat/ChatMessage.jsx
+++ b/frontend/src/components/Chat/ChatMessage.jsx
@@ -43,12 +43,6 @@ const ChatMessage = ({ userId, conversation, messages, newMessage, setNewMessage
             resize="none"
             onFocus={(e) => e.target.rows = 3}
             onBlur={(e) => e.target.rows = 1}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && !e.shiftKey) {
-                e.preventDefault();
-                handleSendMessage();
-              }
-            }}
           />
         <Button colorScheme="teal" onClick={handleSendMessage}>送信</Button>
       </Flex>


### PR DESCRIPTION
## Overview
This pull request addresses an issue where pressing the Enter key while composing a message in the chat component would inadvertently send the message. The behavior is now adjusted so that messages are only sent when the "Send" button is clicked.

## Changes
- Updated `ChatMessage.jsx` to remove the `onKeyDown` event listener for the Enter key.
- Ensured that messages are only sent when the "Send" button is clicked.

## Files Changed
- `ChatMessage.jsx`
- `Chat.jsx`

## Testing
1. **Navigate to the Chat page**:
   - Confirm that the chat page loads without errors.
2. **Compose a message**:
   - Type a message into the text area.
   - Press Enter: The message should not be sent.
   - Click the "Send" button: The message should be sent and displayed in the chat history.
3. **Verify message display**:
   - Confirm that the sent message appears in the chat window with the correct timestamp and user information.

## Screenshots
N/A

## Additional Notes
- This change improves the user experience by preventing accidental message sends when pressing the Enter key.
- No additional dependencies or configurations are required.

Please review the changes and provide feedback. Thank you!